### PR TITLE
Init Fastlane and Add create_app lane

### DIFF
--- a/iOS/Gemfile
+++ b/iOS/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "fastlane"

--- a/iOS/TheNewFlickr.xcodeproj/project.pbxproj
+++ b/iOS/TheNewFlickr.xcodeproj/project.pbxproj
@@ -904,7 +904,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = lintschool.com.TheNewFlickr;
+				PRODUCT_BUNDLE_IDENTIFIER = esma.TheNewFlickr;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;
@@ -924,7 +924,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = lintschool.com.TheNewFlickr;
+				PRODUCT_BUNDLE_IDENTIFIER = esma.TheNewFlickr;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;

--- a/iOS/fastlane/Appfile
+++ b/iOS/fastlane/Appfile
@@ -1,0 +1,6 @@
+app_identifier("esma.TheNewFlickr") # The bundle identifier of your app
+apple_id("asmaatarek93@gmail.com") # Your Apple email address
+
+
+# For more information about the Appfile, see:
+#     https://docs.fastlane.tools/advanced/#appfile

--- a/iOS/fastlane/Fastfile
+++ b/iOS/fastlane/Fastfile
@@ -1,0 +1,23 @@
+# This file contains the fastlane.tools configuration
+# You can find the documentation at https://docs.fastlane.tools
+#
+# For a list of all available actions, check out
+#
+#     https://docs.fastlane.tools/actions
+#
+# For a list of all available plugins, check out
+#
+#     https://docs.fastlane.tools/plugins/available-plugins
+#
+
+# Uncomment the line if you want fastlane to automatically update itself
+# update_fastlane
+
+default_platform(:ios)
+
+platform :ios do
+  desc "Create App on Apple Developer and App Store Connect"
+  lane :create_app do
+    produce
+  end
+end

--- a/iOS/fastlane/README.md
+++ b/iOS/fastlane/README.md
@@ -1,0 +1,29 @@
+fastlane documentation
+================
+# Installation
+
+Make sure you have the latest version of the Xcode command line tools installed:
+
+```
+xcode-select --install
+```
+
+Install _fastlane_ using
+```
+[sudo] gem install fastlane -NV
+```
+or alternatively using `brew install fastlane`
+
+# Available Actions
+## iOS
+### ios create_app
+```
+fastlane ios create_app
+```
+Create App on Apple Developer and App Store Connect
+
+----
+
+This README.md is auto-generated and will be re-generated every time [_fastlane_](https://fastlane.tools) is run.
+More information about fastlane can be found on [fastlane.tools](https://fastlane.tools).
+The documentation of fastlane can be found on [docs.fastlane.tools](https://docs.fastlane.tools).

--- a/iOS/fastlane/report.xml
+++ b/iOS/fastlane/report.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="fastlane.lanes">
+    
+    
+    
+      
+      <testcase classname="fastlane.lanes" name="0: default_platform" time="0.000194">
+        
+      </testcase>
+    
+      
+      <testcase classname="fastlane.lanes" name="1: produce" time="50.85005">
+        
+      </testcase>
+    
+  </testsuite>
+</testsuites>


### PR DESCRIPTION

## Description

Init Fastlane, add create_app lane by using **Produce** which creates iOS apps in both App Store Connect and the Apple Developer Portal.

## How to test

Open both App Store Connect and Apple Developer the app is exist

## Screenshot

## Notes
