### PR TITLE
Add team id in Appfile

### DIFF
--- a/iOS/fastlane/Appfile
+++ b/iOS/fastlane/Appfile
@@ -1,5 +1,8 @@
 app_identifier("esma.TheNewFlickr") # The bundle identifier of your app
 apple_id("asmaatarek93@gmail.com") # Your Apple email address
+team_id "QVCZFS2TP2" # Developer Portal Team ID
+itc_team_id "121820337" # App Store Connect Team ID
+
 
 
 # For more information about the Appfile, see:

--- a/iOS/fastlane/report.xml
+++ b/iOS/fastlane/report.xml
@@ -5,12 +5,12 @@
     
     
       
-      <testcase classname="fastlane.lanes" name="0: default_platform" time="0.000194">
+      <testcase classname="fastlane.lanes" name="0: default_platform" time="0.000164">
         
       </testcase>
     
       
-      <testcase classname="fastlane.lanes" name="1: produce" time="50.85005">
+      <testcase classname="fastlane.lanes" name="1: produce" time="63.967594">
         
       </testcase>
     


### PR DESCRIPTION

## Description

Add team id for Apple Developer Portal and App Store Connect as my email is registered on different organization and Fastlane ask to specify it.

## How to test
Remove App from App Store and run fastlane create_app, it doesn't ask for team
